### PR TITLE
fix missing string format arg

### DIFF
--- a/chalmers/service/sysv_service.py
+++ b/chalmers/service/sysv_service.py
@@ -49,7 +49,7 @@ class SysVService(object):
         log.info('Platform: %s' % (platform.linux_distribution()[0] or 'Unknown'))
         log.info('Using Linux sysv chkconfig')
         if target_user:
-            log.info('Chalmers service for target user' % target_user)
+            log.info('Chalmers service for target user: {}'.format(target_user))
         else:
             log.info('Chalmers service for root user')
 


### PR DESCRIPTION
Fixes the missing string format argument that @tpowellcio mentioned in flowdock:

```bash
[anaconda@anaconda-build-linux-32-1 ~]$ sudo /home/anaconda/miniconda/bin/chalmers @startup
Platform: CentOS
Using Linux sysv chkconfig
[TypeError] not all arguments converted during string formatting
Traceback (most recent call last):
  File "/home/anaconda/miniconda/bin/chalmers", line 6, in <module>
    sys.exit(main())
  File "/home/anaconda/miniconda/lib/python2.7/site-packages/chalmers/scripts/chalmers_main.py", line 36, in main
    run_command(args, exit=exit)
  File "/home/anaconda/miniconda/lib/python2.7/site-packages/clyent/__init__.py", line 135, in run_command
    return args.main(args)
  File "/home/anaconda/miniconda/lib/python2.7/site-packages/chalmers/commands/at_startup.py", line 45, in main
    service = SystemService(args.target_user)
  File "/home/anaconda/miniconda/lib/python2.7/site-packages/chalmers/service/sysv_service.py", line 52, in __init__
    log.info('Chalmers service for target user' % target_user)
TypeError: not all arguments converted during string formatting
```