### PR TITLE
Update runner.py

### DIFF
--- a/chalmers/scripts/runner.py
+++ b/chalmers/scripts/runner.py
@@ -31,7 +31,7 @@ def main():
 
 
     logfile = config.main_logfile()
-    setup_logging(logger, logging.INFO, use_color=False, logfile=logfile, show_tb=True)
+    setup_logging(logger, logging.INFO, use_color='never', logfile=logfile, show_tb=True)
     cli_logger.error("Starting program: %s" % args.name)
     prog = Program(args.name)
     prog.start_sync()


### PR DESCRIPTION
Since https://github.com/Anaconda-Server/clyent/commit/8856c26efd9b989c904794aae3a5194131bff829, use_color only accepts `always`, `never` and `tty` as valid arguments.

This is causing `chalmers start` to totally fail.